### PR TITLE
correct destructive fail to close table syntax

### DIFF
--- a/doc/trex_book_basic.asciidoc
+++ b/doc/trex_book_basic.asciidoc
@@ -2700,7 +2700,7 @@ Full command line reference can be found xref:cml-line[here]
 | cap2/imix_fast_1g.yaml     |  imix profile with 1600 flows normalized to 1Gb/sec.
 | cap2/imix_fast_1g_100k_flows.yaml    |  imix profile with 100k flows normalized to 1Gb/sec.
 | cap2/imix_64.yaml  |  64byte UDP packets profile 
-|========================  
+|=================
 
 
 === Mimicking stateless traffic under stateful mode


### PR DESCRIPTION
in other unrelated work, my diffs were going crazy due to this syntax problem in failure to close a table around line#2703
Signed-off-by: Matt Callaghan <mcallaghan@sandvine.com>